### PR TITLE
NET7: Fix NETSDK1137 warning

### DIFF
--- a/Braver/Braver.csproj
+++ b/Braver/Braver.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net7.0-windows</TargetFramework>


### PR DESCRIPTION
This PR fixes a minor warning. It won't literally change anything other than removing this every time you build the project.

See https://learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1137